### PR TITLE
Added support for child windows on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub use window::{WindowProxy, PollEventsIterator, WaitEventsIterator};
 pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
 pub use native_monitor::NativeMonitorId;
 
+use std::os::raw::c_void;
+
 mod api;
 mod platform;
 mod events;
@@ -221,7 +223,7 @@ pub struct WindowAttributes {
     pub dimensions: Option<(u32, u32)>,
 
     /// Window parent handle.
-    pub parent: Option<*mut libc::c_void>,
+    pub parent: Option<*mut c_void>,
 
     /// The minimum dimensions a window can be, If this is `None`, the window will have no minimum dimensions (aside from reserved).
     ///

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -350,6 +350,9 @@ impl Window {
 impl Drop for Window {
     #[inline]
     fn drop(&mut self) {
+        callback::CONTEXT_STASH.with(|context_stash| {
+            (*context_stash.borrow_mut()).remove(&self.window.0)/*.unwrap()*/;
+        });
         unsafe {
             user32::PostMessageW(self.window.0, winapi::WM_DESTROY, 0, 0);
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -11,7 +11,7 @@ use native_monitor::NativeMonitorId;
 use libc;
 use platform;
 
-use libc::c_void;
+use std::os::raw::c_void;
 
 impl WindowBuilder {
     /// Initializes a new `WindowBuilder` with default values.
@@ -37,7 +37,7 @@ impl WindowBuilder {
         self.window.dimensions = Some((width, height));
         self
     }
-    
+
     /// Sets a minimum dimension size for the window
     ///
     /// Width and height are in pixels.
@@ -238,7 +238,7 @@ impl Window {
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         self.window.get_inner_size()
     }
-    
+
     /// Returns the size in points of the client area of the window.
     ///
     /// The client area is the content of the window, excluding the title bar and borders.


### PR DESCRIPTION
The API changed slightly, `WindowBuilder::with_parent()` now takes a `*mut std::os::raw::c_void` instead of `libc::c_void` so that plugins don't have to depend on libc.